### PR TITLE
Fixed reviewer name endpoint

### DIFF
--- a/lambdas/getReviewByReviewerName.ts
+++ b/lambdas/getReviewByReviewerName.ts
@@ -9,7 +9,7 @@ export const handler: APIGatewayProxyHandlerV2 = async (event, context) => {
     console.log("Event: ", event);
     
 const movieId = parseInt(event?.pathParameters?.movieId ?? "");
-const reviewerName = event?.queryStringParameters?.reviewerName;
+const reviewerName = event?.pathParameters?.reviewerName;
 
 if (!movieId || !reviewerName) {
   return {

--- a/lib/rest-api-stack.ts
+++ b/lib/rest-api-stack.ts
@@ -247,7 +247,7 @@ export class RestAPIStack extends cdk.Stack {
     );
 
     // const movieReviewersNameEndpoint = movieReviewsEndpoint.addResource("{reviewerName}");
-    const movieReviewersNameEndpoint = movieEndpoint.addResource("reviewsByName");
+    const movieReviewersNameEndpoint = movieReviewsEndpoint.addResource("{reviewerName}");
     movieReviewersNameEndpoint.addMethod(
       "GET",
       new apig.LambdaIntegration(getReviewByReviewerNameFn, { proxy: true })

--- a/seed/movies.ts
+++ b/seed/movies.ts
@@ -85,7 +85,7 @@ export const movieCasts: MovieCast[] = [
 export const movieReviews: MovieReview[] = [
   {
     movieId: 1234,
-    reviewerName: "Saoirse O'Donovan",
+    reviewerName: "Saoirse Donovan",
     reviewDate: "2023-10-20",
     rating: 5,
     content: "Great movie!"


### PR DESCRIPTION
I had been passing the reviewer name into the query string but it is now passed as a path parameter, as specified in the assignmnet specification.