### PR TITLE
Year endpoint now working with regex

### DIFF
--- a/lib/rest-api-stack.ts
+++ b/lib/rest-api-stack.ts
@@ -32,7 +32,7 @@ export class RestAPIStack extends cdk.Stack {
     const movieReviewsTable = new dynamodb.Table(this, "MovieReviewsTable", {
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
       partitionKey: { name: "movieId", type: dynamodb.AttributeType.NUMBER },
-      sortKey: { name: "reviewerName", type: dynamodb.AttributeType.STRING },
+      sortKey: { name: "reviewDate", type: dynamodb.AttributeType.STRING },
       removalPolicy: cdk.RemovalPolicy.DESTROY,
       tableName: "MovieReview",
     });


### PR DESCRIPTION
Struggled with getting this endpoint working but after using regular expressions to determine if digits are present in a year format has allowed for the correct handling of that data if that condition is met to return the correct review.